### PR TITLE
Fix: new thread message send fails silently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 dist-cli/
 *.tsbuildinfo
+PROJECT_SPEC.md

--- a/src/App.vue
+++ b/src/App.vue
@@ -402,8 +402,6 @@ watch(
 )
 
 async function submitFirstMessageForNewThread(text: string): Promise<void> {
-  if (!newThreadCwd.value) return
-
   try {
     const threadId = await sendMessageToNewThread(text, newThreadCwd.value)
     if (!threadId) return

--- a/src/components/icons/IconTablerSearch.vue
+++ b/src/components/icons/IconTablerSearch.vue
@@ -1,0 +1,6 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.35-4.35" />
+  </svg>
+</template>

--- a/src/components/sidebar/SidebarThreadControls.vue
+++ b/src/components/sidebar/SidebarThreadControls.vue
@@ -22,6 +22,8 @@
       <IconTablerRefresh class="sidebar-thread-controls-icon" />
     </button>
 
+    <slot />
+
     <button
       v-if="showNewThreadButton"
       class="sidebar-thread-controls-button"

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1631,16 +1631,20 @@ export function useDesktopState() {
     const nextText = text.trim()
     const targetCwd = cwd.trim()
     const selectedModel = selectedModelId.value.trim()
-    if (!nextText || !targetCwd) return ''
+    if (!nextText) return ''
 
     isSendingMessage.value = true
     error.value = ''
     let threadId = ''
 
     try {
-      threadId = await startThread(targetCwd, selectedModel || undefined)
+      threadId = await startThread(targetCwd || undefined, selectedModel || undefined)
       if (!threadId) return ''
 
+      resumedThreadById.value = {
+        ...resumedThreadById.value,
+        [threadId]: true,
+      }
       setSelectedThreadId(threadId)
       shouldAutoScrollOnNextAgentEvent = true
       setTurnSummaryForThread(threadId, null)


### PR DESCRIPTION
## Summary

- Remove the `cwd` requirement that silently blocked new thread creation when no folder was selected (or no existing threads existed to derive a folder from)
- Mark newly created threads as "resumed" immediately after `thread/start`, preventing a redundant `thread/resume` call that fails with 502 because the thread is already loaded in memory
- Pass `cwd` as optional to `thread/start` (matching the API schema where `cwd` is nullable), allowing the server to use its default working directory

## Problem

When sending a message from the home screen to start a new chat session, two issues caused silent failures:

1. `submitFirstMessageForNewThread` returned early without feedback when `newThreadCwd` was empty
2. Even when `thread/start` succeeded, the subsequent `thread/resume` call inside `startTurnForThread` failed with a 502 because freshly started threads are already loaded — they don't need resuming

## Test plan

- [ ] Start the app with no existing threads and send a message from the home screen
- [ ] Start the app with existing threads, navigate to home, and send a message without selecting a folder
- [ ] Start the app with existing threads, select a folder, and send a message (existing flow)
- [ ] Verify the thread is created, the turn starts, and the UI navigates to the new thread


Made with [Cursor](https://cursor.com)